### PR TITLE
Updated ColorInputWidget to have both editable hex field and color selector

### DIFF
--- a/wagtail_color_panel/fields.py
+++ b/wagtail_color_panel/fields.py
@@ -11,7 +11,3 @@ class ColorField(models.CharField):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('max_length', 7)
         super().__init__(*args, **kwargs)
-
-    #def get_panel(self):
-    #    from wagtail_color_panel.edit_handlers import NativeColorPanel
-    #    return NativeColorPanel

--- a/wagtail_color_panel/static/wagtail_color_panel/css/color-input-widget.css
+++ b/wagtail_color_panel/static/wagtail_color_panel/css/color-input-widget.css
@@ -1,3 +1,10 @@
-.color-input-widget {
-    height: 60px;
+input.color-input-widget {
+    width: 140px;
+    height: 50px;
+    vertical-align: bottom;
+}
+
+input[type="color"].color-input-widget {
+    padding: 10px;
+    width: 70px;
 }

--- a/wagtail_color_panel/templates/wagtail_color_panel/widgets/color-input-widget.html
+++ b/wagtail_color_panel/templates/wagtail_color_panel/widgets/color-input-widget.html
@@ -1,0 +1,15 @@
+{% include "django/forms/widgets/text.html" %}
+
+{% with widget.attrs.id as widget_id %}
+<input class="color-input-widget" type="color" name="{{ widget_id }}-color" value="{{ widget.value }}" maxlength="7" id="{{ widget_id }}-color">
+
+<script>
+  document.getElementById("{{ widget_id }}-color").addEventListener("input", function(evt) {
+    document.getElementById("{{ widget_id }}").value = evt.target.value;
+  }, false);
+
+  document.getElementById("{{ widget_id }}").addEventListener("input", function(evt) {
+    document.getElementById("{{ widget_id }}-color").value = evt.target.value;
+  }, false);
+</script>
+{% endwith %}

--- a/wagtail_color_panel/widgets.py
+++ b/wagtail_color_panel/widgets.py
@@ -45,18 +45,14 @@ class PolyfillColorInputWidget(widgets.TextInput):
         )
 
 
-class ColorInputWidget(widgets.Input):
-    input_type = "color"
+class ColorInputWidget(widgets.TextInput):
+    template_name = "wagtail_color_panel/widgets/color-input-widget.html"
 
     def __init__(self, attrs=None):
         default_attrs = {"class": "color-input-widget"}
         attrs = attrs or {}
         attrs = {**default_attrs, **attrs}
         super().__init__(attrs=attrs)
-
-    # def get_panel(self):
-    #     from wagtail_color_panel.edit_handlers import NativeColorPanel
-    #     return NativeColorPanel
 
     @property
     def media(self):


### PR DESCRIPTION
Hi @marteinn, I've made a small update to your wagtail color panel to allow color values to be entered manually, as well as the using the color input selector. If the text input changes, the color should also change and vice versa.

Hope you like it :)

<img width="716" alt="Screenshot 2021-01-09 at 16 41 13" src="https://user-images.githubusercontent.com/1315296/104103667-52f30980-529b-11eb-95e2-926c4919b8d2.png">
 