### PR TITLE
Updated ColorInputWidget to work with latest wagtail

### DIFF
--- a/wagtail_color_panel/static/wagtail_color_panel/js/color-input-widget-telepath.js
+++ b/wagtail_color_panel/static/wagtail_color_panel/js/color-input-widget-telepath.js
@@ -1,0 +1,15 @@
+(function() {
+    function ColorInput(html) {
+        this.html = html;
+    }
+    ColorInput.prototype.render = function(placeholder, name, id, initialState) {
+        var html = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
+        placeholder.outerHTML = html;
+
+        var colorInput = new ColorInputWidget(id);
+        colorInput.setState(initialState);
+        return colorInput;
+    };
+
+    window.telepath.register('wagtail_color_panel.widgets.ColorInput', ColorInput);
+})();

--- a/wagtail_color_panel/static/wagtail_color_panel/js/color-input-widget.js
+++ b/wagtail_color_panel/static/wagtail_color_panel/js/color-input-widget.js
@@ -1,0 +1,31 @@
+function ColorInputWidget(id) {
+    /*
+    id = the ID of the HTML element where color input behaviour should be attached
+    */
+    this.textInput = $('#' + id);
+    this.colorInput = $('#' + id + '-color');
+
+    this.textInput.on('input', this.handleUpdate.bind(this));
+    this.colorInput.on('input', this.handleUpdate.bind(this));
+}
+
+ColorInputWidget.prototype.handleUpdate = function(evt) {
+    this.setState(evt.target.value);
+};
+
+ColorInputWidget.prototype.setState = function(newState) {
+    this.textInput.val(newState);
+    this.colorInput.val(newState);
+};
+
+ColorInputWidget.prototype.getState = function() {
+    return this.textInput.val();
+};
+
+ColorInputWidget.prototype.getValue = function() {
+    return this.textInput.val();
+};
+
+ColorInputWidget.prototype.focus = function() {
+    this.textInput.focus();
+}

--- a/wagtail_color_panel/templates/wagtail_color_panel/widgets/color-input-widget.html
+++ b/wagtail_color_panel/templates/wagtail_color_panel/widgets/color-input-widget.html
@@ -1,17 +1,4 @@
 <div class="color-input-widget">
     {% include "django/forms/widgets/text.html" %}
-
-    {% with widget.attrs.id as widget_id %}
-    <input class="color-input-widget__color-input" type="color" name="{{ widget_id }}-color" value="{{ widget.value }}" maxlength="7" id="{{ widget_id }}-color">
-
-    <script>
-        document.getElementById("{{ widget_id }}-color").addEventListener("input", function(evt) {
-            document.getElementById("{{ widget_id }}").value = evt.target.value;
-        }, false);
-
-        document.getElementById("{{ widget_id }}").addEventListener("input", function(evt) {
-            document.getElementById("{{ widget_id }}-color").value = evt.target.value;
-        }, false);
-    </script>
-    {% endwith %}
+    <input class="color-input-widget__color-input" type="color" name="{{ widget.attrs.id }}-color" value="{{ widget.value }}" maxlength="7" id="{{ widget.attrs.id }}-color">
 </div>


### PR DESCRIPTION
Hi @marteinn after updating a project to the latest Wagtail (2.14.1) I noticed that the ColorInputWidget wasn't quite working as expected when the widget was used in streamfield blocks, the JS in the template was being ignored. I think that this is because of Wagtail is now using Telepath. Anyway, I have cribbed off https://github.com/wagtail/wagtail-generic-chooser and come up with a fix. Seems to be working, but I've not looked at the tests. What do you think?