### PR TITLE
Add CI testing for Wagtail 6.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,9 +33,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -U .[test]
-        pip install -q wagtail~=${{ matrix.wagtail-version }}
-        pip install -q django~=${{ matrix.django-version }}
-        pip list # For debugging purposes
+        pip install -q wagtail==${{ matrix.wagtail-version }}.*
+        pip install -q django==${{ matrix.django-version }}.*
+        pip show wagtail django # For debugging purposes
     - name: Run tests
       run: |
         python runtests.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        wagtail-version: ["5.2", "6.2", "6.3"]
+        wagtail-version: ["5.2", "6.2", "6.3", "6.4"]
         django-version: ["4.2", "5.0", "5.1"]
         exclude:
           - python-version: "3.13"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
         pip install -U .[test]
         pip install -q wagtail~=${{ matrix.wagtail-version }}
         pip install -q django~=${{ matrix.django-version }}
+        pip list # For debugging purposes
     - name: Run tests
       run: |
         python runtests.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -U .[test]
-        pip install -q wagtail==${{ matrix.wagtail-version }}
+        pip install -q wagtail==${{ matrix.wagtail-version }}.*
+        pip install -q django==${{ matrix.django-version }}.*
     - name: Run tests
       run: |
         python runtests.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -U .[test]
-        pip install -q wagtail==${{ matrix.wagtail-version }}.*
-        pip install -q django==${{ matrix.django-version }}.*
+        pip install -q wagtail~=${{ matrix.wagtail-version }}
+        pip install -q django~=${{ matrix.django-version }}
     - name: Run tests
       run: |
         python runtests.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Add CI testing for Wagtail 6.4
 ### Fixed
 ### Removed
 


### PR DESCRIPTION
This pull request includes updates to the CI testing matrix for Wagtail 6.4.

Changes to CI testing:

* Added Wagtail 6.4 to the `wagtail-version` matrix for CI testing.
* Ensure the latest patch versions are installed for tests

Documentation updates:

* Added a note about adding CI testing for Wagtail 6.4 in the "Changed" section.