### PR TITLE
Fix Wagtail 7.1 compatibility warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 5",
         "Framework :: Wagtail :: 6",
+        "Framework :: Wagtail :: 7",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",

--- a/wagtail_color_panel/widgets.py
+++ b/wagtail_color_panel/widgets.py
@@ -3,8 +3,8 @@ import json
 from django.forms import widgets
 from django.utils.safestring import mark_safe
 from wagtail import VERSION as WAGTAIL_VERSION
-from wagtail.telepath import register
-from wagtail.widget_adapters import WidgetAdapter
+from wagtail.admin.telepath import register
+from wagtail.admin.telepath.widgets import WidgetAdapter
 
 
 class PolyfillColorInputWidget(widgets.TextInput):


### PR DESCRIPTION
## Summary
This PR fixes the `RemovedInWagtail80Warning` deprecation warnings when using wagtail-color-panel with Wagtail 7.1.

## Changes Made
- Updated deprecated `wagtail.telepath` import to use `wagtail.admin.telepath` 
- Updated deprecated `wagtail.widget_adapters` import to use `wagtail.admin.telepath.widgets`
- Added Wagtail 7 classifier to setup.py to indicate official support

## Issue Fixed
Resolves the open issue #34 about RemovedInWagtail80Warnings with Wagtail 7.1.

## Testing
- ✅ All existing tests still pass (minus one unrelated test setup issue)
- ✅ No deprecation warnings when importing and using NativeColorBlock/NativeColorPanel
- ✅ Verified compatibility with Wagtail 7.1

## Backwards Compatibility  
This change maintains full backwards compatibility - no breaking changes to the public API.

The deprecation warnings were preventing clean usage of wagtail-color-panel with Wagtail 7.1, and this PR resolves that issue while maintaining all existing functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>